### PR TITLE
Fixing addProduct annotation to meet swagger spec, adding CORS bundle…

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -13,6 +13,7 @@ class AppKernel extends Kernel
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+            new Nelmio\CorsBundle\NelmioCorsBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new AppBundle\AppBundle()

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -78,3 +78,20 @@ swiftmailer:
     username: '%mailer_user%'
     password: '%mailer_password%'
     spool: { type: memory }
+
+nelmio_cors:
+        defaults:
+            allow_credentials: false
+            allow_origin: []
+            allow_headers: []
+            allow_methods: []
+            expose_headers: []
+            max_age: 0
+            hosts: []
+            origin_regex: false
+        paths:
+            '^/':
+                allow_origin: ['*']
+                allow_headers: ['*']
+                allow_methods: ['POST', 'PUT', 'GET', 'DELETE']
+                max_age: 3600

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "doctrine/orm": "^2.5",
         "incenteev/composer-parameter-handler": "^2.0",
         "mashape/unirest-php": "^3.0",
+        "nelmio/cors-bundle": "^1.5",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "symfony/assetic-bundle": "^2.8",

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\Serializer;
  * @package AppBundle\Controller
  *
  * @SWG\Swagger(
- *     host="localhost:8000",
+ *     host="127.0.0.1:8000",
  *     schemes={"http"},
  *     @SWG\Info(
  *         version="1.0",

--- a/src/AppBundle/Controller/ReviewController.php
+++ b/src/AppBundle/Controller/ReviewController.php
@@ -16,11 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 class ReviewController extends ApiController
 {
     /**
-     * @SWG\Get(
-     *     path="/reviews/{review_id}",
-     *     @SWG\Response(response="200", description="Success")
-     * )
-     *
      * @Route("/reviews/{id}")
      * @Method({"GET"})
      */

--- a/src/AppBundle/Entity/Product.php
+++ b/src/AppBundle/Entity/Product.php
@@ -3,10 +3,11 @@
 namespace AppBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Swagger\Annotations as SWG;
 
 /**
  * Products
- *
+ * @SWG\Definition(required={"productName", "upc"}, type="object")
  * @ORM\Table(name="products")
  * @ORM\Entity
  */
@@ -16,7 +17,7 @@ class Product
 
     /**
      * @var int
-     *
+     * @SWG\Property(example=1)
      * @ORM\Column(name="product_id", type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
@@ -25,49 +26,49 @@ class Product
 
     /**
      * @var string
-     *
+     * @SWG\Property(example="Amazon Echo")
      * @ORM\Column(name="product_name", type="string", length=255)
      */
     private $productName;
 
     /**
      * @var string
-     *
+     * @SWG\Property(example="null")
      * @ORM\Column(name="product_description", type="text", nullable=true)
      */
     private $productDescription;
 
     /**
      * @var float
-     *
+     * @SWG\Property(example="null")
      * @ORM\Column(name="product_rating", type="float", nullable=true)
      */
     private $productRating;
 
     /**
      * @var int
-     *
+     * @SWG\Property(example="null")
      * @ORM\Column(name="review_count", type="integer", nullable=true)
      */
     private $reviewCount;
 
     /**
      * @var string
-     *
+     * @SWG\Property(example="Amazon")
      * @ORM\Column(name="product_manufacturer", type="string", length=50, nullable=true)
      */
     private $productManufacturer;
 
     /**
      * @var string
-     *
+     * @SWG\Property(example="848719071733")
      * @ORM\Column(name="upc", type="string", length=12, unique=true)
      */
     private $upc;
 
     /**
      * @var string
-     *
+     * @SWG\Property(example="null")
      * @ORM\Column(name="product_image", type="string", length=255, nullable=true)
      */
     private $productImage;

--- a/web/swagger.json
+++ b/web/swagger.json
@@ -4,7 +4,7 @@
         "title": "StarredUp API",
         "version": "1.0"
     },
-    "host": "localhost:8000",
+    "host": "127.0.0.1:8000",
     "schemes": [
         "http"
     ],
@@ -23,7 +23,7 @@
         "/products/{productId}": {
             "get": {
                 "tags": [
-                    "product"
+                    "products"
                 ],
                 "summary": "Get a single product by ID",
                 "description": "Return JSON object of a single product",
@@ -45,7 +45,7 @@
                         "description": "Success => [product => {product}]"
                     },
                     "404": {
-                        "description": "No product found"
+                        "description": "No product found for ID: {productId}"
                     }
                 }
             }
@@ -53,56 +53,26 @@
         "/products/add": {
             "post": {
                 "tags": [
-                    "product"
+                    "products"
                 ],
                 "summary": "Save or Update a single product with a payload",
                 "description": "Return JSON with the effected product ID",
                 "operationId": "addProduct",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
                 "parameters": [
                     {
-                        "name": "productId",
+                        "name": "body",
                         "in": "body",
-                        "description": "The product ID, only needed if updating",
-                        "required": false,
-                        "type": "integer"
-                    },
-                    {
-                        "name": "productName",
-                        "in": "body",
-                        "description": "The product name",
+                        "description": "Update a product by adding the productId to the payload",
                         "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "productDescription",
-                        "in": "body",
-                        "description": "A short or long description of the product",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "productManufacturer",
-                        "in": "body",
-                        "description": "The manufacurer of the product",
-                        "required": false,
-                        "type": "string"
-                    },
-                    {
-                        "name": "upc",
-                        "in": "body",
-                        "description": "The product UPC",
-                        "required": true,
-                        "type": "string"
-                    },
-                    {
-                        "name": "isActive",
-                        "in": "body",
-                        "description": "If the product is active, only needed if updating an inactive product",
-                        "required": false,
-                        "type": "integer"
+                        "schema": {
+                            "$ref": "#/definitions/Product"
+                        }
                     }
                 ],
                 "responses": {
@@ -115,14 +85,17 @@
                 }
             }
         },
-        "/products/{product_id}/remove": {
+        "/products/{productId}/remove": {
             "post": {
                 "tags": [
-                    "product"
+                    "products"
                 ],
                 "summary": "Deactivate a product",
                 "description": "Return JSON object of the effected product and isActive status",
                 "operationId": "removeProduct",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -139,21 +112,58 @@
                     "200": {
                         "description": "Success => [productId => {productId}, isActive => {isActive}]"
                     },
-                    "400": {
+                    "404": {
+                        "description": "No product found for ID: {productId}"
+                    },
+                    "409": {
                         "description": "Product has already been removed"
-                    }
-                }
-            }
-        },
-        "/reviews/{review_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "description": "Success"
                     }
                 }
             }
         }
     },
-    "definitions": {}
+    "definitions": {
+        "Product": {
+            "required": [
+                "productName",
+                "upc"
+            ],
+            "properties": {
+                "productId": {
+                    "type": "integer",
+                    "example": 1
+                },
+                "productName": {
+                    "type": "string",
+                    "example": "Amazon Echo"
+                },
+                "productDescription": {
+                    "type": "string",
+                    "example": "null"
+                },
+                "productRating": {
+                    "type": "number",
+                    "format": "float",
+                    "example": "null"
+                },
+                "reviewCount": {
+                    "type": "integer",
+                    "example": "null"
+                },
+                "productManufacturer": {
+                    "type": "string",
+                    "example": "Amazon"
+                },
+                "upc": {
+                    "type": "string",
+                    "example": "848719071733"
+                },
+                "productImage": {
+                    "type": "string",
+                    "example": "null"
+                }
+            },
+            "type": "object"
+        }
+    }
 }


### PR DESCRIPTION
- Cleaned up Swagger annotations for addProduct. Each property doesn't need to be listed, I pointed it to the Product Entity and added annotations there.
- Added a CORS bundle to assist with testing POST requests in Swagger UI.
- Changed response type to `JsonResponse` from `Response`. This allows us to skip calling `json_encode` every time.